### PR TITLE
Fix 'already initialized constant' warning

### DIFF
--- a/lib/fluent/plugin/out_azure-storage-append-blob.rb
+++ b/lib/fluent/plugin/out_azure-storage-append-blob.rb
@@ -16,6 +16,7 @@ module Fluent
       helpers :formatter, :inject
 
       DEFAULT_FORMAT_TYPE = "out_file"
+      AZURE_BLOCK_SIZE_LIMIT = 4 * 1024 * 1024 - 1
   
       config_param :path, :string, :default => ""
       config_param :azure_storage_account, :string, :default => nil
@@ -25,9 +26,6 @@ module Fluent
       config_param :auto_create_container, :bool, :default => true
       config_param :format, :string, :default => DEFAULT_FORMAT_TYPE
       config_param :time_slice_format, :string, :default => '%Y%m%d'
-  
-      DEFAULT_FORMAT_TYPE = "out_file"
-      AZURE_BLOCK_SIZE_LIMIT = 4 * 1024 * 1024 - 1
   
       config_section :format do
         config_set_default :@type, DEFAULT_FORMAT_TYPE


### PR DESCRIPTION
This commit fixes the following warning:

```
/var/lib/gems/2.3.0/gems/fluent-plugin-azure-storage-append-blob-0.1.1/lib/fluent/plugin/out_azure-storage-append-blob.rb:29: warning: already initialized constant Fluent::Plugin::AzureStorageAppendBlobOut::DEFAULT_FORMAT_TYPE
/var/lib/gems/2.3.0/gems/fluent-plugin-azure-storage-append-blob-0.1.1/lib/fluent/plugin/out_azure-storage-append-blob.rb:18: warning: previous definition of DEFAULT_FORMAT_TYPE was here
```

Signed-off-by: Cristian Klein <cristian.klein@elastisys.com>