### PR TITLE
Use GET on the container to check if the storage container exists

### DIFF
--- a/lib/fluent/plugin/out_azure-storage-append-blob.rb
+++ b/lib/fluent/plugin/out_azure-storage-append-blob.rb
@@ -115,10 +115,23 @@ module Fluent
           tmp.unlink
         end
       end
+
+      def container_exists?(container)
+        begin
+          @bs.get_container_properties(container)
+        rescue Azure::Core::Http::HTTPError => ex
+          if ex.status_code == 404 # container does not exist
+            return false
+          else
+            raise
+          end
+        end
+        return true
+      end
   
       private
       def ensure_container
-        if ! @bs.list_containers.find { |c| c.name == @azure_container }
+        if ! container_exists? @azure_container
           if @auto_create_container
             @bs.create_container(@azure_container)
           else


### PR DESCRIPTION
The list_containers op will return a max of 5000 containers. This
causes the container check to fail when there are > 5000 containers
in the storage account. Using a GET on the container avoids this limit.

This fixes https://github.com/microsoft/fluent-plugin-azure-storage-append-blob/issues/15