### PR TITLE
Fix duplicate bytes

### DIFF
--- a/lib/fluent/plugin/out_azure-storage-append-blob.rb
+++ b/lib/fluent/plugin/out_azure-storage-append-blob.rb
@@ -203,7 +203,7 @@ module Fluent
           begin
             size = [content.length - position, AZURE_BLOCK_SIZE_LIMIT].min
             log.debug "azure_storage_append_blob: append_blob.chunk: content[#{position}..#{position + size}]"
-            @bs.append_blob_block(@azure_container, @azure_storage_path, content[position..position + size])
+            @bs.append_blob_block(@azure_container, @azure_storage_path, content[position..position + size - 1])
             position += size
             break if position >= content.length
           rescue Azure::Core::Http::HTTPError => e


### PR DESCRIPTION
Fix #24 

The logic which checks if content exceeds the block max has a bug where the last byte is sent again.

In a simpler form the bug is just:
x = 'test'
x[0..2] is 'tes'
x[2..] is 'st'

I think this never caused an issue with max len buffers because the constant subtracts 1, so there's room in the request to send that extra byte.

I applied this fix and ran the test described in #24 and the blob contents match the text file.

I also added some tests for this area.